### PR TITLE
#51 Made textures get rendered in their native size

### DIFF
--- a/Palmy/src/Application/Window.cpp
+++ b/Palmy/src/Application/Window.cpp
@@ -73,8 +73,8 @@ namespace Palmy {
 	}
 	void WindowsWindow::Start()
 	{
-		m_Texture = ResourceManager::GetTexture2D(1153661826);
-		m_Renderer = std::make_unique<Renderer2D>();
+		m_Texture = ResourceManager::GetTexture2D(710627734);
+		m_Renderer = std::make_unique<Renderer2D>(m_WindowData.Width,m_WindowData.Height);
 	}
 	void WindowsWindow::Update()
 	{
@@ -86,7 +86,7 @@ namespace Palmy {
 			ImGui::End();
 		}
 		m_Renderer->StartDraw();
-		m_Renderer->RenderQuad(Transform2D(), m_Texture, { {0.0f,384.0f},{128.0f,128.0f} });
+		m_Renderer->RenderQuad(Transform2D(), m_Texture);
 		m_Renderer->DrawBatch();
 		ImGuiContext::EndFrame();
 		glfwPollEvents();

--- a/Palmy/src/Rendering/Renderer2D.cpp
+++ b/Palmy/src/Rendering/Renderer2D.cpp
@@ -7,10 +7,11 @@
 #include "../Application/ResourceManager.h"
 
 namespace Palmy {
-	Renderer2D::Renderer2D()
+	Renderer2D::Renderer2D(float windowWidth, float windowHeight)
 		:m_BatchData(),m_TextureIndex(0),
 		m_OrthographicCamera({0.0f,0.0f,1.0f},{0.0f,0.0f,-1.0f},-1.0f, 1.0f, 1.0f,-1.0f,0.1f,10.0f),
-		m_CameraController(m_OrthographicCamera)
+		m_CameraController(m_OrthographicCamera),
+		m_WindowSize({windowWidth, windowHeight})
 	{
 		m_Shader = std::make_unique<ShaderProgram>(*ResourceManager::GetShader(2204820834), *ResourceManager::GetShader(4187305228));
 		m_Shader->Bind();
@@ -41,6 +42,7 @@ namespace Palmy {
 		glm::mat4 transformMatrix = transform.GetTransformMatrix();
 		QuadVertexData vertexData;
 		int32_t textureNumber = SetTextureNumber(texture);
+		SetTextureQuadPosition(vertexData, subTextureInfo);
 		for (size_t i = 0; i < QUAD_VERTEX_SIZE; i++)
 		{
 			vertexData.VertexDatas[i].Position = transformMatrix * vertexData.VertexDatas[i].Position;
@@ -90,8 +92,21 @@ namespace Palmy {
 		m_BatchData.clear();
 		m_VertexArray->Unbind();
 	}
+	inline void Renderer2D::SetTextureQuadPosition(QuadVertexData& vertexData, const SubTextureInfo& subTextureInfo)
+	{
+		float vMin = -1.0f * (subTextureInfo.Size.x / 2) / m_WindowSize.x;
+		float uMin = -1.0f * (subTextureInfo.Size.y / 2) / m_WindowSize.y;
+		float vMax = (subTextureInfo.Size.x / 2) / m_WindowSize.x;
+		float uMax = (subTextureInfo.Size.y / 2) / m_WindowSize.y;
 
-	void Renderer2D::SetTextureCoordinates(QuadVertexData& vertexData, std::shared_ptr<Texture2D>texture, const SubTextureInfo& subTextureInfo)
+		vertexData.VertexDatas[0].Position = { vMin, uMin, 0.0f, 1.0f };
+		vertexData.VertexDatas[1].Position = { vMax, uMin, 0.0f, 1.0f };
+		vertexData.VertexDatas[2].Position = { vMax, uMax, 0.0f, 1.0f };
+		vertexData.VertexDatas[3].Position = { vMax, uMax, 0.0f, 1.0f };
+		vertexData.VertexDatas[4].Position = { vMin, uMax, 0.0f, 1.0f };
+		vertexData.VertexDatas[5].Position = { vMin, uMin, 0.0f, 1.0f };
+	}
+	inline void Renderer2D::SetTextureCoordinates(QuadVertexData& vertexData, std::shared_ptr<Texture2D>texture, const SubTextureInfo& subTextureInfo)
 	{
 		float texWidth = texture->GetWidth();
 		float texHeight = texture->GetHeight();

--- a/Palmy/src/Rendering/Renderer2D.h
+++ b/Palmy/src/Rendering/Renderer2D.h
@@ -30,7 +30,7 @@ namespace Palmy {
 	};
 	class Renderer2D {
 	public:
-		Renderer2D();
+		Renderer2D(float windowWidth, float windowHeight);
 		void RenderQuad(const Transform2D&, std::shared_ptr<Texture2D>);
 		void RenderQuad(const Transform2D&, std::shared_ptr<Texture2D>, const SubTextureInfo& subTextureInfo);
 		void RenderQuad(const Transform2D&, const glm::vec4 color);
@@ -38,13 +38,15 @@ namespace Palmy {
 		void StartDraw();
 		void DrawBatch();
 	private:
-		void SetTextureCoordinates(QuadVertexData& vertexData, std::shared_ptr<Texture2D>texture, const SubTextureInfo& subTextureInfo);
+		inline void SetTextureQuadPosition(QuadVertexData& vertexData, const SubTextureInfo& subTextureInfo);
+		inline void SetTextureCoordinates(QuadVertexData& vertexData, std::shared_ptr<Texture2D>texture, const SubTextureInfo& subTextureInfo);
 	private:
 		std::unique_ptr<VertexArray> m_VertexArray;
 		std::unique_ptr<VertexBuffer> m_VertexBuffer;
 		std::unique_ptr<ShaderProgram> m_Shader;
 		std::vector<QuadVertexData> m_BatchData;
 		std::unordered_map<std::shared_ptr<Texture2D>, int32_t> m_TextureSet;
+		glm::vec2 m_WindowSize;
 		int32_t m_TextureIndex;
 		OrthoGraphicCamera m_OrthographicCamera;
 		CameraController m_CameraController;


### PR DESCRIPTION
### Changes
- Window (The window width and height are now passed to the renderer)
- Renderer (The screen coordiantes for the textures are now calculated based on their height)